### PR TITLE
FIX: Add anon and `everyone` group support

### DIFF
--- a/app/controllers/discourse_group_category_banner_ads/admin/admin_group_category_banner_ads_controller.rb
+++ b/app/controllers/discourse_group_category_banner_ads/admin/admin_group_category_banner_ads_controller.rb
@@ -27,6 +27,8 @@ class DiscourseGroupCategoryBannerAds::Admin::AdminGroupCategoryBannerAdsControl
     # we need to clear the cache after create to ensure that we don't render stale data
     # from the cache
     Site.clear_cache
+    Site.clear_anon_cache!
+
     render json:
              DiscourseGroupCategoryBannerAds::DetailedBannerAdSerializer.new(
                banner_ad,
@@ -45,6 +47,7 @@ class DiscourseGroupCategoryBannerAds::Admin::AdminGroupCategoryBannerAdsControl
     # we need to clear the cache after update to ensure that we don't render stale data
     # from the cache
     Site.clear_cache
+    Site.clear_anon_cache!
 
     render json:
              DiscourseGroupCategoryBannerAds::DetailedBannerAdSerializer.new(
@@ -57,6 +60,11 @@ class DiscourseGroupCategoryBannerAds::Admin::AdminGroupCategoryBannerAdsControl
     params.require(:id)
     banner_ad = DiscourseGroupCategoryBannerAds::BannerAd.find(params[:id])
     banner_ad.destroy!
+    # we need to clear the cache after destroy to ensure that we don't render stale data
+    # from the cache
+    Site.clear_cache
+    Site.clear_anon_cache!
+
     render json: success_json
   end
 

--- a/assets/javascripts/discourse/connectors/before-list-area/banner-ads.gjs
+++ b/assets/javascripts/discourse/connectors/before-list-area/banner-ads.gjs
@@ -2,20 +2,6 @@ import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import BannerAd from "../../components/banner-ad";
 
-const userHasBannerGroupsMembership = (bannerGroupIds, currentUser) => {
-  return bannerGroupIds.some((g) =>
-    currentUser.groups.map((ug) => ug.id).includes(g)
-  );
-};
-
-const bannerGroupIdsEmpty = (bannerGroupIds) => {
-  return bannerGroupIds.length === 0;
-};
-
-const bannerGroupsIncludesEveryone = (bannerGroupIds) => {
-  return !!bannerGroupIds.includes(0);
-};
-
 const bannerCategoriesIncludesCategory = (categoryId, bannerCategoryIds) => {
   return bannerCategoryIds.includes(categoryId);
 };
@@ -30,16 +16,7 @@ export default class BannerAds extends Component {
           @outletArgs.category.id banner.category_ids
         )
       }}
-        {{#if (bannerGroupsIncludesEveryone banner.group_ids)}}
-          <BannerAd @banner={{banner}} />
-        {{else if
-          (userHasBannerGroupsMembership banner.group_ids this.currentUser)
-        }}
-          <BannerAd @banner={{banner}} />
-        {{else if (bannerGroupIdsEmpty banner.group_ids)}}
-          {{! display for anon if group_ids are empty }}
-          <BannerAd @banner={{banner}} />
-        {{/if}}
+        <BannerAd @banner={{banner}} />
       {{/if}}
     {{/each}}
   </template>

--- a/assets/javascripts/discourse/connectors/before-list-area/banner-ads.gjs
+++ b/assets/javascripts/discourse/connectors/before-list-area/banner-ads.gjs
@@ -3,12 +3,13 @@ import { inject as service } from "@ember/service";
 import BannerAd from "../../components/banner-ad";
 
 const userHasBannerGroupsMembership = (bannerGroupIds, currentUser) => {
-  return (
-    !!currentUser &&
-    bannerGroupIds.some((g) =>
-      currentUser.groups.map((ug) => ug.id).includes(g)
-    )
+  return bannerGroupIds.some((g) =>
+    currentUser.groups.map((ug) => ug.id).includes(g)
   );
+};
+
+const bannerGroupIdsEmpty = (bannerGroupIds) => {
+  return bannerGroupIds.length === 0;
 };
 
 const bannerGroupsIncludesEveryone = (bannerGroupIds) => {
@@ -34,6 +35,9 @@ export default class BannerAds extends Component {
         {{else if
           (userHasBannerGroupsMembership banner.group_ids this.currentUser)
         }}
+          <BannerAd @banner={{banner}} />
+        {{else if (bannerGroupIdsEmpty banner.group_ids)}}
+          {{! display for anon if group_ids are empty }}
           <BannerAd @banner={{banner}} />
         {{/if}}
       {{/if}}

--- a/assets/stylesheets/common/banner-ads.scss
+++ b/assets/stylesheets/common/banner-ads.scss
@@ -31,7 +31,9 @@
     }
 
     .banner-ad-value {
-      .category-selector {
+      .category-selector,
+      .group-chooser,
+      .banner-ad-description {
         width: calc(100% - 1em);
         margin-right: 0.3em;
       }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -28,7 +28,7 @@ en:
         description: "The categories where the banner will be displayed"
       group_ids:
         label: "Groups"
-        description: "The groups that will be able to see the banner"
+        description: "The groups that will be able to see the banner. If no groups are selected, the banner will be visible to anonymous users"
       enabled:
         label: "Enabled"
         description: "Enable or disable the banner"

--- a/plugin.rb
+++ b/plugin.rb
@@ -46,12 +46,18 @@ after_initialize do
 
   add_to_serializer(:site, :banner_ads) do
     banner_ads =
-      DiscourseGroupCategoryBannerAds::BannerAd
-        .where(enabled: true)
-        .where("category_ids && (?)", Category.secured(scope).select("ARRAY_AGG(categories.id)"))
+      DiscourseGroupCategoryBannerAds::BannerAd.where(enabled: true).where(
+        "category_ids && (?)",
+        Category.secured(scope).select("ARRAY_AGG(categories.id)"),
+      )
 
     if scope.user.present?
-      banner_ads = banner_ads.where("group_ids && ARRAY[?, ?]", scope.user.groups.pluck(:id), Group::AUTO_GROUPS[:everyone])
+      banner_ads =
+        banner_ads.where(
+          "group_ids && ARRAY[?, ?]",
+          scope.user.groups.pluck(:id),
+          Group::AUTO_GROUPS[:everyone],
+        )
     else
       # Only show ads with no groups specified to users who are not logged in
       banner_ads = banner_ads.where(group_ids: [])

--- a/spec/system/group_category_banner_ads_spec.rb
+++ b/spec/system/group_category_banner_ads_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe "Category - Discourse Group Category Banner Ads", type: :system, 
         expect(page.find(".group-category-banner-ad-text")).to have_text(text)
       end
 
+      it "does not display banner ad to anon when no group membership" do
+        visit "/c/#{valid_category.id}"
+        expect(page).not_to have_css(".group-category-banner-ad")
+      end
+
       it "displays display banner ad to user without group membership when 'everyone' group included" do
         DiscourseGroupCategoryBannerAds::BannerAd.find_by(title: title).update!(
           group_ids: [Group::AUTO_GROUPS[:trust_level_1], Group::AUTO_GROUPS[:everyone]],

--- a/spec/system/group_category_banner_ads_spec.rb
+++ b/spec/system/group_category_banner_ads_spec.rb
@@ -53,9 +53,7 @@ RSpec.describe "Category - Discourse Group Category Banner Ads", type: :system, 
       end
 
       it "displays banner ad to anon when no group_ids are set" do
-        DiscourseGroupCategoryBannerAds::BannerAd.find_by(title: title).update!(
-          group_ids: [],
-        )
+        DiscourseGroupCategoryBannerAds::BannerAd.find_by(title: title).update!(group_ids: [])
 
         visit "/c/#{valid_category.id}"
         expect(page).to have_css(".group-category-banner-ad")

--- a/spec/system/group_category_banner_ads_spec.rb
+++ b/spec/system/group_category_banner_ads_spec.rb
@@ -52,6 +52,26 @@ RSpec.describe "Category - Discourse Group Category Banner Ads", type: :system, 
         expect(page.find(".group-category-banner-ad-text")).to have_text(updated_text)
       end
 
+      it "displays banner ad to anon when no group_ids are set" do
+        DiscourseGroupCategoryBannerAds::BannerAd.find_by(title: title).update!(
+          group_ids: [],
+        )
+
+        visit "/c/#{valid_category.id}"
+        expect(page).to have_css(".group-category-banner-ad")
+        expect(page.find(".group-category-banner-ad-text")).to have_text(text)
+      end
+
+      it "displays display banner ad to user without group membership when 'everyone' group included" do
+        DiscourseGroupCategoryBannerAds::BannerAd.find_by(title: title).update!(
+          group_ids: [Group::AUTO_GROUPS[:trust_level_1], Group::AUTO_GROUPS[:everyone]],
+        )
+
+        sign_in(user_not_in_valid_group)
+        visit "/c/#{valid_category.id}"
+        expect(page).to have_css(".group-category-banner-ad")
+      end
+
       it "does not display banner ad to user without group membership" do
         sign_in(user_not_in_valid_group)
         visit "/c/#{valid_category.id}"


### PR DESCRIPTION
- clear anon cache when updating / creating / deleting banner ad
- add functionality to show banner ad to anon when group_ids is empty
- ensure banner ads are displayed when `everyone` group is selected