### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+< 3.4.0.beta2-dev: 5b5188dac305fa43d3b325f1fdd4025a0a4a205b
 < 3.4.0.beta1-dev: 3d50d70f08b633be62eb8e046f31ea72b43a9e16
 < 3.3.0.beta1-dev: f1c7ada2637c52f4239420ebce8ac2e880d8de30

--- a/assets/javascripts/discourse/components/admin/banner-table.gjs
+++ b/assets/javascripts/discourse/components/admin/banner-table.gjs
@@ -54,7 +54,7 @@ const BannerTable = <template>
                 {{#if bannerAd.enabled}}
                   {{icon "check"}}
                 {{else}}
-                  {{icon "times"}}
+                  {{icon "xmark"}}
                 {{/if}}
               </span>
             </td>


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.