### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/admin/banner-table.gjs
+++ b/assets/javascripts/discourse/components/admin/banner-table.gjs
@@ -62,12 +62,12 @@ const BannerTable = <template>
               <div class="banner-ads-table-actions">
                 <DButton
                   @action={{fn @setEditing bannerAd}}
-                  @icon="pencil-alt"
+                  @icon="pencil"
                   class="edit-banner"
                 />
                 <DButton
                   @action={{fn @deleteBannerAd bannerAd}}
-                  @icon="trash-alt"
+                  @icon="trash-can"
                   class="delete-banner"
                 />
               </div>


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.